### PR TITLE
ci: add metanorma workflows and release manifest

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,21 @@
+name: generate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  site:
+    uses: actions-mn/.github/.github/workflows/metanorma-generate.yml@v1
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths: ['sources/**', 'metanorma.yml', 'metanorma.release.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@v1
+    with:
+      default-visibility: private
+    secrets: inherit

--- a/metanorma.release.yml
+++ b/metanorma.release.yml
@@ -1,0 +1,4 @@
+documents:
+  - source: sources/cc-xxxxx.adoc
+  - source: sources/iso-xxxxx.adoc
+    visibility: private

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -1,8 +1,12 @@
----
 metanorma:
   deploy:
-    email: "travis-ci@metanorma.org"
+    email: travis-ci@metanorma.org
+  source:
+    files:
+    - sources/cc-xxxxx.adoc
+    - sources/iso-xxxxx.adoc
 relaton:
   collection:
-    name: Computer applications in terminology -- Naming -- Structure of personal names
+    name: Computer applications in terminology -- Naming -- Structure of personal
+      names
     organization: CalConnect/ISO


### PR DESCRIPTION
Adds CI workflows using shared reusable workflows from `actions-mn/.github`.

Changes:
- Creates `generate.yml` referencing `actions-mn/.github/.github/workflows/metanorma-generate.yml@v1`
- Creates `release.yml` referencing `actions-mn/.github/.github/workflows/metanorma-release.yml@v1`
- Sets `default-visibility: private` (safe-by-default)
- Adds `metanorma.release.yml` (cc-xxxxx public, iso-xxxxx private)
- Updates `metanorma.yml` to include `source.files`
- Switches default branch from master to main